### PR TITLE
Use press and release actions instead of click

### DIFF
--- a/left_ring/code.py
+++ b/left_ring/code.py
@@ -90,18 +90,26 @@ while True:
         # right_BTN.update()
 
         if left_BTN.value is False:
-            mouse.click(Mouse.LEFT_BUTTON)
+            mouse.press(Mouse.LEFT_BUTTON)
             print("Left Button is pressed")
             blue_led.value = True
             green_led.value = False
-            time.sleep(0.2)  # sleep for debounce
-        elif right_BTN.value is False:
-            mouse.click(Mouse.RIGHT_BUTTON)
+            time.sleep(0.1)  # sleep for debounce
+        elif left_BTN.value is True:
+            mouse.release(Mouse.LEFT_BUTTON)
+            print("Left Button is released")
+            
+        if right_BTN.value is False:
+            mouse.press(Mouse.RIGHT_BUTTON)
             print("Right Button is pressed")
             blue_led.value = True
             green_led.value = False
-            time.sleep(0.2)  # sleep for debounce
-        elif not scrollup_BTN.value:
+            time.sleep(0.1)  # sleep for debounce
+        elif right_BTN.value is True:
+            mouse.release(Mouse.RIGHT_BUTTON)
+            print("Right Button is released")
+            
+        if not scrollup_BTN.value:
             mouse.move(wheel=1)
             print("Up Button is pressed")
             blue_led.value = True

--- a/right_ring/code.py
+++ b/right_ring/code.py
@@ -90,18 +90,26 @@ while True:
         # right_BTN.update()
 
         if left_BTN.value is False:
-            mouse.click(Mouse.LEFT_BUTTON)
+            mouse.press(Mouse.LEFT_BUTTON)
             print("Left Button is pressed")
             blue_led.value = True
             green_led.value = False
-            time.sleep(0.2)
-        elif right_BTN.value is False:
-            mouse.click(Mouse.RIGHT_BUTTON)
+            time.sleep(0.1)
+        elif left_BTN.value is True:
+            mouse.release(Mouse.LEFT_BUTTON)
+            print("Left Button is released")
+        
+        if right_BTN.value is False:
+            mouse.press(Mouse.RIGHT_BUTTON)
             print("Right Button is pressed")
             blue_led.value = True
             green_led.value = False
-            time.sleep(0.2)
-        elif not scrollup_BTN.value:
+            time.sleep(0.1)
+        elif right_BTN.value is True:
+            mouse.release(Mouse.RIGHT_BUTTON)
+            print("Right Button is released")
+            
+        if not scrollup_BTN.value:
             mouse.move(wheel=1)
             print("Up Button is pressed")
             blue_led.value = True


### PR DESCRIPTION
This change makes the virtual mouse buttons follow the state of the buttons on the ring. The prior implementation used "click" which performed a full press and release cycle, and this occurred as soon as the button was pushed on the ring. Holding the ring button issued repeated click events. The code in the pull request uses "press" and "release" in order for the virtual mouse to match exactly the state of the ring. It becomes possible to click and hold the mouse button down. In DCS this is a great benefit for switches and actions that require holding for a short duration. Additionally, some modules did not reliably detect the very rapid click event, but that has been resolved via this change.

It is unknown what, if any, effect this change has on battery life, but it has lasted the full duration of my play tests.